### PR TITLE
Implement Project Kalkan monitoring system

### DIFF
--- a/include/Config.h
+++ b/include/Config.h
@@ -1,0 +1,69 @@
+#pragma once
+
+#include <Arduino.h>
+
+namespace config {
+
+// Flow sensor pin
+constexpr gpio_num_t FLOW_SENSOR_PIN = GPIO_NUM_25;
+
+// Analog inputs
+constexpr gpio_num_t LEVEL_SENSOR_PIN = GPIO_NUM_36;  // ADC1 channel 0
+constexpr gpio_num_t JOYSTICK_X_PIN = GPIO_NUM_32;
+constexpr gpio_num_t JOYSTICK_Y_PIN = GPIO_NUM_33;
+
+// Buttons
+constexpr gpio_num_t BUTTON1_PIN = GPIO_NUM_14;
+constexpr gpio_num_t BUTTON2_PIN = GPIO_NUM_27;
+
+// SD Card pins (VSPI)
+constexpr int SD_MOSI = 23;
+constexpr int SD_MISO = 19;
+constexpr int SD_SCK = 18;
+constexpr int SD_CS = 5;
+
+// LCD
+constexpr uint8_t LCD_ADDR = 0x27;
+constexpr uint8_t LCD_COLS = 16;
+constexpr uint8_t LCD_ROWS = 2;
+
+// Sampling and timing
+constexpr uint32_t FLOW_WINDOW_MS = 1000;  // sliding window length
+constexpr size_t FLOW_STATS_WINDOW = 120;  // last N samples for statistics
+constexpr size_t LEVEL_STATS_WINDOW = 120;
+constexpr TickType_t SENSOR_TASK_DELAY = pdMS_TO_TICKS(200);
+constexpr uint32_t ANALOG_OVERSAMPLE = 10;
+constexpr float ANALOG_ALPHA = 0.2f;  // EMA smoothing factor
+
+// Logging
+constexpr uint32_t DEFAULT_LOG_INTERVAL_MS = 1000;
+constexpr size_t RAM_LOG_CAPACITY = 1200;  // 20 minutes at 1 Hz
+constexpr uint64_t SD_MIN_FREE_BYTES = 4ULL * 1024ULL * 1024ULL * 1024ULL;  // 4 GB
+
+// Calibration defaults
+constexpr float LEVEL_V_MIN = 0.48f;
+constexpr float LEVEL_V_MAX = 2.40f;
+constexpr float LEVEL_RANGE_CM = 500.0f;
+constexpr float WATER_DENSITY = 1.0f;  // relative
+
+// Joystick
+constexpr int JOYSTICK_DEADBAND = 200;
+constexpr int JOYSTICK_MAX = 4095;
+constexpr float JOYSTICK_ACCEL_THRESHOLD = 0.8f;
+constexpr float JOYSTICK_ACCEL_MULTIPLIER = 1.6f;
+
+// Buttons
+constexpr uint32_t BUTTON_DEBOUNCE_MS = 25;
+constexpr uint32_t BUTTON_HOLD_MS = 5000;
+
+// Queue sizes
+constexpr size_t SENSOR_QUEUE_LENGTH = 10;
+
+}  // namespace config
+
+#ifdef DEBUG_PROJECT_KALKAN
+constexpr bool kDebugMode = true;
+#else
+constexpr bool kDebugMode = false;
+#endif
+

--- a/include/Conversions.h
+++ b/include/Conversions.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <algorithm>
+
+#include "SensorData.h"
+
+inline float convertPulseToFlowLps(float frequencyHz) {
+  return frequencyHz / 12.0f;
+}
+
+inline float convertVoltageToHeight(float voltage, const CalibrationFactors& calibration) {
+  float vRange = calibration.vMax - calibration.vMin;
+  if (vRange <= 0.01f) {
+    return 0.0f;
+  }
+  float fraction = (voltage - calibration.vMin) / vRange;
+  fraction = std::max(0.0f, std::min(1.0f, fraction));
+  float densityFactor = (calibration.densityRatio > 0.0f) ? (1.0f / calibration.densityRatio) : 1.0f;
+  float height = fraction * calibration.referenceHeightCm * densityFactor;
+  return height;
+}
+

--- a/include/LoggingManager.h
+++ b/include/LoggingManager.h
@@ -1,0 +1,66 @@
+#pragma once
+
+#include <SdFat.h>
+#include <SPI.h>
+#include <array>
+
+#include "Config.h"
+#include "SensorData.h"
+
+class LoggingManager {
+ public:
+  explicit LoggingManager(SdFat& sd) : sd_(sd) {}
+
+  void begin();
+  void update(time_t now, const LogRecord& record);
+  void triggerEvent(const LogRecord& record);
+  void feedEvent(const LogRecord& record);
+  void loop();
+  void setLogInterval(uint32_t intervalMs) { logIntervalMs_ = intervalMs; }
+  uint32_t logInterval() const { return logIntervalMs_; }
+
+ private:
+  bool ensureFilesystem();
+  bool ensureDailyFile(time_t now);
+  bool writeRecord(File& file, const LogRecord& record);
+  void maintainStorage();
+  void refreshEventFileName(time_t now);
+  void flushRamBufferToFile(File& file);
+
+  struct RamBuffer {
+    std::array<LogRecord, config::RAM_LOG_CAPACITY> buffer;
+    size_t head = 0;
+    size_t count = 0;
+
+    void push(const LogRecord& record) {
+      buffer[head] = record;
+      head = (head + 1) % buffer.size();
+      if (count < buffer.size()) {
+        count++;
+      }
+    }
+
+    template <typename Callback>
+    void forEachOldestFirst(Callback cb) const {
+      size_t valid = count;
+      size_t start = (head + buffer.size() - count) % buffer.size();
+      for (size_t i = 0; i < valid; ++i) {
+        size_t idx = (start + i) % buffer.size();
+        cb(buffer[idx]);
+      }
+    }
+  };
+
+  SdFat& sd_;
+  SPIClass spi_{VSPI};
+  File dailyFile_;
+  File eventFile_;
+  String currentDailyPath_;
+  String currentEventPath_;
+  bool eventActive_ = false;
+  uint32_t logIntervalMs_ = config::DEFAULT_LOG_INTERVAL_MS;
+  uint32_t lastLogMs_ = 0;
+  uint32_t eventEndMs_ = 0;
+  RamBuffer ramBuffer_;
+};
+

--- a/include/RunningStatistics.h
+++ b/include/RunningStatistics.h
@@ -1,0 +1,87 @@
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <limits>
+
+// Simple running statistics using Welford's algorithm and fixed-size history for percentiles.
+
+template <size_t WindowSize>
+class RunningStatistics {
+ public:
+  RunningStatistics() { reset(); }
+
+  void reset() {
+    count_ = 0;
+    mean_ = 0.0f;
+    m2_ = 0.0f;
+    min_ = std::numeric_limits<float>::infinity();
+    max_ = -std::numeric_limits<float>::infinity();
+    head_ = 0;
+    filled_ = false;
+  }
+
+  void push(float value) {
+    if (!std::isfinite(value)) {
+      return;
+    }
+
+    // Update Welford running stats
+    count_++;
+    float delta = value - mean_;
+    mean_ += delta / static_cast<float>(count_);
+    m2_ += delta * (value - mean_);
+    min_ = std::min(min_, value);
+    max_ = std::max(max_, value);
+
+    history_[head_] = value;
+    head_ = (head_ + 1) % WindowSize;
+    if (head_ == 0) {
+      filled_ = true;
+    }
+  }
+
+  size_t count() const { return count_; }
+  float mean() const { return mean_; }
+  float variance() const { return (count_ > 1) ? m2_ / static_cast<float>(count_ - 1) : 0.0f; }
+  float stddev() const { return std::sqrt(variance()); }
+  float minimum() const { return (count_ == 0) ? 0.0f : min_; }
+  float maximum() const { return (count_ == 0) ? 0.0f : max_; }
+
+  float median() const { return percentile(0.5f); }
+
+  float percentile(float pct) const {
+    if (!filled_ && head_ == 0 && count_ == 0) {
+      return 0.0f;
+    }
+    size_t valid = filled_ ? WindowSize : head_;
+    if (valid == 0) {
+      return 0.0f;
+    }
+
+    std::array<float, WindowSize> temp;
+    std::copy(history_.begin(), history_.begin() + valid, temp.begin());
+    std::sort(temp.begin(), temp.begin() + valid);
+
+    float position = pct * static_cast<float>(valid - 1);
+    size_t lower = static_cast<size_t>(std::floor(position));
+    size_t upper = static_cast<size_t>(std::ceil(position));
+    float fraction = position - static_cast<float>(lower);
+    float lowerValue = temp[lower];
+    float upperValue = temp[upper];
+    return lowerValue + (upperValue - lowerValue) * fraction;
+  }
+
+ private:
+  size_t count_ = 0;
+  float mean_ = 0.0f;
+  float m2_ = 0.0f;
+  float min_ = 0.0f;
+  float max_ = 0.0f;
+  size_t head_ = 0;
+  bool filled_ = false;
+  std::array<float, WindowSize> history_{};
+};
+

--- a/include/SensorData.h
+++ b/include/SensorData.h
@@ -1,0 +1,64 @@
+#pragma once
+
+#include <Arduino.h>
+
+#include "Config.h"
+
+struct FlowMetrics {
+  float instantaneousLps = 0.0f;
+  float baselineLps = 0.0f;  // Q_n
+  float differencePct = 0.0f;
+  float minimumHealthyLps = 0.0f;  // Qmin
+  float meanLps = 0.0f;  // Qμ
+  float medianLps = 0.0f;  // Qη
+};
+
+struct LevelMetrics {
+  float instantaneousCm = 0.0f;  // h
+  float baselineCm = 0.0f;       // hθ
+  float fullTankCm = 0.0f;       // hΣ
+  float differencePct = 0.0f;    // hdif
+  float noiseMetric = 0.0f;      // K, percent or qualitative
+};
+
+struct SensorSnapshot {
+  time_t timestamp = 0;
+  uint32_t pulseCount = 0;
+  float pulseFrequencyHz = 0.0f;
+  float levelVoltage = 0.0f;
+  FlowMetrics flow;
+  LevelMetrics level;
+};
+
+struct StatisticsSummary {
+  float minValue = 0.0f;
+  float maxValue = 0.0f;
+  float meanValue = 0.0f;
+  float medianValue = 0.0f;
+  float stddevValue = 0.0f;
+};
+
+struct AnalyticsState {
+  FlowMetrics flow;
+  LevelMetrics level;
+  StatisticsSummary flowStats;
+  StatisticsSummary levelStats;
+};
+
+struct CalibrationFactors {
+  float vMin = config::LEVEL_V_MIN;
+  float vMax = config::LEVEL_V_MAX;
+  float referenceHeightCm = config::LEVEL_RANGE_CM;
+  float densityRatio = config::WATER_DENSITY;
+};
+
+struct LogRecord {
+  time_t timestamp;
+  String iso8601;
+  uint32_t pulseCount;
+  float pulseFrequency;
+  float levelVoltage;
+  FlowMetrics flow;
+  LevelMetrics level;
+};
+

--- a/include/UIManager.h
+++ b/include/UIManager.h
@@ -1,0 +1,64 @@
+#pragma once
+
+#include <LiquidCrystal_I2C.h>
+
+#include "Config.h"
+#include "SensorData.h"
+
+class UIManager {
+ public:
+  enum class Screen {
+    Boot,
+    TimeSetting,
+    DateSetting,
+    Main,
+    LevelStats,
+    FlowStats,
+    Calibration
+  };
+
+  UIManager(LiquidCrystal_I2C& lcd);
+
+  void begin();
+  void setScreen(Screen screen);
+  Screen currentScreen() const { return screen_; }
+  void update(const AnalyticsState& state, const SensorSnapshot& latest);
+  void handleJoystick(float x, float y);
+  void handleButtons(bool button1Pressed, bool button2Pressed, bool bothHeld);
+  bool calibrationRequested() const { return calibrationRequested_; }
+  void setCalibrationValue(float value);
+  float calibrationInputValue() const { return calibrationInput_; }
+  void resetCalibrationRequest();
+  void setTimeSetting(struct tm timeinfo);
+  struct tm editableTime() const { return editableTime_; }
+  void commitTime(struct tm timeinfo);
+
+ private:
+  void createCustomChars();
+  void renderBoot();
+  void renderTimeSetting();
+  void renderDateSetting();
+  void renderMain(const AnalyticsState& state);
+  void renderStats(const StatisticsSummary& stats, const char* title);
+  void renderCalibration();
+  void advanceMainScroll();
+  String buildFlowMetricString(const AnalyticsState& state) const;
+  String buildLevelMetricString(const AnalyticsState& state) const;
+  void pushToLcd(uint8_t row, const String& content);
+  void updateTimeEditing(int digitIndex, int delta);
+  void updateDateEditing(int fieldIndex, int delta);
+
+  LiquidCrystal_I2C& lcd_;
+  Screen screen_ = Screen::Boot;
+  uint32_t bootStartMs_ = 0;
+  uint32_t lastScrollMs_ = 0;
+  uint8_t scrollIndex_ = 0;
+  String lastRow0_;
+  String lastRow1_;
+  bool calibrationRequested_ = false;
+  float calibrationInput_ = 0.0f;
+  struct tm editableTime_ {};
+  uint8_t timeCursor_ = 0;
+  uint8_t dateField_ = 0;
+};
+

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,15 +1,12 @@
-; PlatformIO Project Configuration File
-;
-;   Build options: build flags, source filter
-;   Upload options: custom upload port, speed and extra flags
-;   Library options: dependencies, extra library storages
-;   Advanced options: extra scripting
-;
-; Please visit documentation for the other options and examples
-; https://docs.platformio.org/page/projectconf.html
-
 [env:esp32dev]
 platform = espressif32
 board = esp32dev
 framework = arduino
-lib_deps = marcoschwartz/LiquidCrystal_I2C@^1.1.4
+monitor_speed = 115200
+build_flags = \
+    -DCORE_DEBUG_LEVEL=3
+lib_deps = \
+    marcoschwartz/LiquidCrystal_I2C@^1.1.4 \
+    greiman/SdFat@^2.2.3 \
+    thomasfredericks/Bounce2@^2.71 \
+    bblanchon/ArduinoJson@^7.0.4

--- a/src/LoggingManager.cpp
+++ b/src/LoggingManager.cpp
@@ -1,0 +1,201 @@
+#include "LoggingManager.h"
+
+#include <FS.h>
+
+#include "Config.h"
+
+namespace {
+String buildDailyPath(time_t now) {
+  struct tm timeinfo;
+  gmtime_r(&now, &timeinfo);
+  char buffer[32];
+  strftime(buffer, sizeof(buffer), "/logs/%Y-%m-%d.csv", &timeinfo);
+  return String(buffer);
+}
+
+String buildEventPath(time_t now) {
+  struct tm timeinfo;
+  gmtime_r(&now, &timeinfo);
+  char buffer[48];
+  strftime(buffer, sizeof(buffer), "/events/event_%Y-%m-%dT%H-%M-%S.csv", &timeinfo);
+  return String(buffer);
+}
+
+String toIso8601(time_t now) {
+  struct tm timeinfo;
+  gmtime_r(&now, &timeinfo);
+  char buffer[32];
+  strftime(buffer, sizeof(buffer), "%Y-%m-%dT%H:%M:%SZ", &timeinfo);
+  return String(buffer);
+}
+
+}  // namespace
+
+void LoggingManager::begin() {
+  spi_.begin(config::SD_SCK, config::SD_MISO, config::SD_MOSI, config::SD_CS);
+  ensureFilesystem();
+}
+
+bool LoggingManager::ensureFilesystem() {
+  if (sd_.cardBegin(&spi_, config::SD_CS, SD_SCK_MHZ(20))) {
+    if (!sd_.begin(&spi_, config::SD_CS, SD_SCK_MHZ(20))) {
+      return false;
+    }
+  } else if (!sd_.begin(config::SD_CS, SD_SCK_MHZ(20))) {
+    return false;
+  }
+
+  if (!sd_.exists("/logs")) {
+    sd_.mkdir("/logs");
+  }
+  if (!sd_.exists("/events")) {
+    sd_.mkdir("/events");
+  }
+  return true;
+}
+
+void LoggingManager::update(time_t now, const LogRecord& record) {
+  ramBuffer_.push(record);
+  uint32_t nowMs = millis();
+  if (nowMs - lastLogMs_ < logIntervalMs_) {
+    return;
+  }
+  lastLogMs_ = nowMs;
+
+  if (!ensureDailyFile(now)) {
+    return;
+  }
+  writeRecord(dailyFile_, record);
+  maintainStorage();
+  if (eventActive_) {
+    feedEvent(record);
+  }
+}
+
+bool LoggingManager::ensureDailyFile(time_t now) {
+  String expected = buildDailyPath(now);
+  if (currentDailyPath_ != expected) {
+    if (dailyFile_) {
+      dailyFile_.close();
+    }
+    currentDailyPath_ = expected;
+    dailyFile_ = sd_.open(currentDailyPath_.c_str(), O_RDWR | O_CREAT | O_AT_END);
+    if (!dailyFile_) {
+      return false;
+    }
+    if (dailyFile_.fileSize() == 0) {
+      dailyFile_.println(F("timestamp,iso8601,pulses,freq_hz,level_v,flow_lps,flow_baseline,flow_diff_pct,flow_min,flow_mean,flow_median,level_cm,level_baseline_cm,level_full_cm,level_diff_pct,level_noise"));
+    }
+  }
+  return true;
+}
+
+bool LoggingManager::writeRecord(File& file, const LogRecord& record) {
+  if (!file) {
+    return false;
+  }
+  String line;
+  line.reserve(196);
+  line += String(record.timestamp);
+  line += ',';
+  line += record.iso8601;
+  line += ',';
+  line += String(record.pulseCount);
+  line += ',';
+  line += String(record.pulseFrequency, 4);
+  line += ',';
+  line += String(record.levelVoltage, 4);
+  line += ',';
+  line += String(record.flow.instantaneousLps, 4);
+  line += ',';
+  line += String(record.flow.baselineLps, 4);
+  line += ',';
+  line += String(record.flow.differencePct, 2);
+  line += ',';
+  line += String(record.flow.minimumHealthyLps, 4);
+  line += ',';
+  line += String(record.flow.meanLps, 4);
+  line += ',';
+  line += String(record.flow.medianLps, 4);
+  line += ',';
+  line += String(record.level.instantaneousCm, 2);
+  line += ',';
+  line += String(record.level.baselineCm, 2);
+  line += ',';
+  line += String(record.level.fullTankCm, 2);
+  line += ',';
+  line += String(record.level.differencePct, 2);
+  line += ',';
+  line += String(record.level.noiseMetric, 2);
+  return file.println(line.c_str());
+}
+
+void LoggingManager::maintainStorage() {
+  uint64_t freeBytes = sd_.freeClusterCount();
+  freeBytes *= sd_.bytesPerCluster();
+  if (freeBytes >= config::SD_MIN_FREE_BYTES) {
+    return;
+  }
+
+  File logsDir = sd_.open("/logs");
+  if (!logsDir) {
+    return;
+  }
+  File oldest;
+  while (freeBytes < config::SD_MIN_FREE_BYTES && (oldest = logsDir.openNextFile())) {
+    String path = String("/logs/") + oldest.name();
+    uint64_t size = oldest.fileSize();
+    oldest.close();
+    sd_.remove(path.c_str());
+    freeBytes += size;
+  }
+  logsDir.close();
+}
+
+void LoggingManager::triggerEvent(const LogRecord& record) {
+  if (eventActive_) {
+    return;
+  }
+  refreshEventFileName(record.timestamp);
+  eventFile_ = sd_.open(currentEventPath_.c_str(), O_RDWR | O_CREAT | O_TRUNC);
+  if (!eventFile_) {
+    return;
+  }
+  eventFile_.println(F("timestamp,iso8601,pulses,freq_hz,level_v,flow_lps,flow_baseline,flow_diff_pct,flow_min,flow_mean,flow_median,level_cm,level_baseline_cm,level_full_cm,level_diff_pct,level_noise"));
+  ramBuffer_.forEachOldestFirst([this](const LogRecord& past) { writeRecord(eventFile_, past); });
+  eventActive_ = true;
+  eventEndMs_ = millis() + (60UL * 60UL * 1000UL);
+  feedEvent(record);
+}
+
+void LoggingManager::feedEvent(const LogRecord& record) {
+  if (!eventActive_) {
+    return;
+  }
+  writeRecord(eventFile_, record);
+  if (millis() > eventEndMs_) {
+    eventActive_ = false;
+    if (eventFile_) {
+      eventFile_.flush();
+      eventFile_.close();
+    }
+  }
+}
+
+void LoggingManager::loop() {
+  if (eventActive_ && eventFile_) {
+    eventFile_.flush();
+  }
+  if (dailyFile_) {
+    dailyFile_.flush();
+  }
+}
+
+void LoggingManager::refreshEventFileName(time_t now) {
+  currentEventPath_ = buildEventPath(now);
+}
+
+void LoggingManager::flushRamBufferToFile(File& file) {
+  ramBuffer_.forEachOldestFirst([&](const LogRecord& record) { writeRecord(file, record); });
+}
+

--- a/src/UIManager.cpp
+++ b/src/UIManager.cpp
@@ -1,0 +1,356 @@
+#include "UIManager.h"
+
+#include <cmath>
+
+namespace {
+const char* kMonthNames[] = {"Ocak",  "Şubat", "Mart",   "Nisan",  "Mayıs",  "Haziran",
+                              "Temmuz", "Ağustos", "Eylül", "Ekim",  "Kasım", "Aralık"};
+
+const uint8_t kMuChar[8] = {0b00000, 0b00000, 0b10001, 0b10001, 0b10001, 0b10011, 0b10101,
+                            0b10000};
+const uint8_t kEtaChar[8] = {0b00100, 0b00100, 0b00100, 0b00110, 0b00101, 0b00101, 0b11111,
+                             0b00000};
+const uint8_t kThetaChar[8] = {0b01110, 0b10001, 0b10001, 0b11111, 0b10001, 0b10001, 0b01110,
+                               0b00000};
+const uint8_t kSigmaChar[8] = {0b11111, 0b10000, 0b01000, 0b00100, 0b01000, 0b10000, 0b11111,
+                               0b00000};
+
+String formatTwoDigit(int value) {
+  char buffer[3];
+  snprintf(buffer, sizeof(buffer), "%02d", value);
+  return String(buffer);
+}
+
+}  // namespace
+
+UIManager::UIManager(LiquidCrystal_I2C& lcd) : lcd_(lcd) {}
+
+void UIManager::begin() {
+  lcd_.init();
+  lcd_.backlight();
+  createCustomChars();
+  bootStartMs_ = millis();
+  setScreen(Screen::Boot);
+}
+
+void UIManager::createCustomChars() {
+  lcd_.createChar(1, const_cast<uint8_t*>(kMuChar));
+  lcd_.createChar(2, const_cast<uint8_t*>(kEtaChar));
+  lcd_.createChar(3, const_cast<uint8_t*>(kThetaChar));
+  lcd_.createChar(4, const_cast<uint8_t*>(kSigmaChar));
+}
+
+void UIManager::setScreen(Screen screen) {
+  screen_ = screen;
+  lastRow0_ = "";
+  lastRow1_ = "";
+  lcd_.clear();
+}
+
+void UIManager::update(const AnalyticsState& state, const SensorSnapshot& latest) {
+  switch (screen_) {
+    case Screen::Boot:
+      renderBoot();
+      if (millis() - bootStartMs_ > 5000) {
+        setScreen(Screen::TimeSetting);
+      }
+      break;
+    case Screen::TimeSetting:
+      renderTimeSetting();
+      break;
+    case Screen::DateSetting:
+      renderDateSetting();
+      break;
+    case Screen::Main:
+      renderMain(state);
+      break;
+    case Screen::LevelStats:
+      renderStats(state.levelStats, "TANK IST");
+      break;
+    case Screen::FlowStats:
+      renderStats(state.flowStats, "FLOW IST");
+      break;
+    case Screen::Calibration:
+      renderCalibration();
+      break;
+  }
+}
+
+void UIManager::renderBoot() {
+  lcd_.noBlink();
+  pushToLcd(0, "Project Kalkan");
+  pushToLcd(1, "Hazirlaniyor...");
+}
+
+void UIManager::renderTimeSetting() {
+  pushToLcd(0, "  Zamanı Ayarla  ");
+  int hour = editableTime_.tm_hour;
+  int minute = editableTime_.tm_min;
+  String line = "    " + formatTwoDigit(hour) + ":" + formatTwoDigit(minute) + "    ";
+  pushToLcd(1, line);
+  lcd_.setCursor(4 + timeCursor_ + (timeCursor_ >= 2 ? 1 : 0), 1);
+  lcd_.blink();
+}
+
+void UIManager::renderDateSetting() {
+  pushToLcd(0, "  Tarihi Ayarla  ");
+  int day = editableTime_.tm_mday;
+  int month = editableTime_.tm_mon;
+  int year = editableTime_.tm_year + 1900;
+  String line = String(day) + " " + kMonthNames[month] + " " + String(year);
+  if (line.length() < 16) {
+    line += String(' ', 16 - line.length());
+  }
+  pushToLcd(1, line);
+  lcd_.setCursor(0, 1);
+  lcd_.noBlink();
+}
+
+void UIManager::renderMain(const AnalyticsState& state) {
+  lcd_.noBlink();
+  advanceMainScroll();
+  String flowMetrics = buildFlowMetricString(state);
+  String levelMetrics = buildLevelMetricString(state);
+  while (flowMetrics.length() < 40) {
+    flowMetrics += flowMetrics;
+  }
+  while (levelMetrics.length() < 40) {
+    levelMetrics += levelMetrics;
+  }
+  size_t flowSpan = (flowMetrics.length() > 10) ? flowMetrics.length() - 10 : flowMetrics.length();
+  if (flowSpan == 0) flowSpan = 1;
+  size_t scrollPos = scrollIndex_ % flowSpan;
+  String row0 = "FLOW:" + flowMetrics.substring(scrollPos, scrollPos + 11);
+  size_t levelSpan = (levelMetrics.length() > 10) ? levelMetrics.length() - 10 : levelMetrics.length();
+  if (levelSpan == 0) levelSpan = 1;
+  size_t scrollPosLevel = scrollIndex_ % levelSpan;
+  String row1 = "TANK:" + levelMetrics.substring(scrollPosLevel, scrollPosLevel + 11);
+  pushToLcd(0, row0);
+  pushToLcd(1, row1);
+}
+
+void UIManager::advanceMainScroll() {
+  if (millis() - lastScrollMs_ > 2000) {
+    lastScrollMs_ = millis();
+    scrollIndex_++;
+    if (scrollIndex_ > 100) scrollIndex_ = 0;
+  }
+}
+
+String UIManager::buildFlowMetricString(const AnalyticsState& state) const {
+  String result = " Q=";
+  result += String(state.flow.instantaneousLps, 2);
+  result += " Qn=";
+  result += String(state.flow.baselineLps, 2);
+  result += " Q";
+  result += (state.flow.differencePct >= 0 ? "+" : "");
+  result += String(state.flow.differencePct, 1);
+  result += "% Qmin=";
+  result += String(state.flow.minimumHealthyLps, 2);
+  result += " Q";
+  result += String((char)1);
+  result += "=";
+  result += String(state.flow.meanLps, 2);
+  result += " Q";
+  result += String((char)2);
+  result += "=";
+  result += String(state.flow.medianLps, 2);
+  result += "   ";
+  return result;
+}
+
+String UIManager::buildLevelMetricString(const AnalyticsState& state) const {
+  String result = " h=";
+  result += String(state.level.instantaneousCm, 1);
+  result += " h";
+  result += String((char)3);
+  result += "=";
+  result += String(state.level.baselineCm, 1);
+  result += " h";
+  result += String((char)4);
+  result += "=";
+  result += String(state.level.fullTankCm, 1);
+  result += " h";
+  result += (state.level.differencePct >= 0 ? "+" : "");
+  result += String(state.level.differencePct, 1);
+  result += "% noise=";
+  result += String(state.level.noiseMetric, 1);
+  result += "%   ";
+  return result;
+}
+
+void UIManager::renderStats(const StatisticsSummary& stats, const char* title) {
+  lcd_.noBlink();
+  char buffer0[17];
+  snprintf(buffer0, sizeof(buffer0), "%.4s mn%.1f mx%.1f", title, stats.minValue, stats.maxValue);
+  pushToLcd(0, String(buffer0));
+  char buffer1[17];
+  snprintf(buffer1, sizeof(buffer1), "μ=%.1f η=%.1f σ=%.1f", stats.meanValue, stats.medianValue,
+           stats.stddevValue);
+  pushToLcd(1, String(buffer1));
+}
+
+void UIManager::renderCalibration() {
+  lcd_.noBlink();
+  pushToLcd(0, " Kalibrasyon h(cm)");
+  char buffer[17];
+  snprintf(buffer, sizeof(buffer), "   %.1f cm", calibrationInput_);
+  pushToLcd(1, String(buffer));
+}
+
+void UIManager::pushToLcd(uint8_t row, const String& content) {
+  String trimmed = content;
+  if (trimmed.length() > config::LCD_COLS) {
+    trimmed = trimmed.substring(0, config::LCD_COLS);
+  }
+  while (trimmed.length() < config::LCD_COLS) {
+    trimmed += ' ';
+  }
+  if (row == 0 && trimmed == lastRow0_) {
+    return;
+  }
+  if (row == 1 && trimmed == lastRow1_) {
+    return;
+  }
+  lcd_.setCursor(0, row);
+  lcd_.print(trimmed);
+  if (row == 0) {
+    lastRow0_ = trimmed;
+  } else {
+    lastRow1_ = trimmed;
+  }
+}
+
+void UIManager::handleJoystick(float x, float y) {
+  if (screen_ == Screen::TimeSetting) {
+    int direction = 0;
+    if (y > 0.2f) direction = 1;
+    if (y < -0.2f) direction = -1;
+    if (direction != 0) {
+      int step = (fabs(y) > config::JOYSTICK_ACCEL_THRESHOLD)
+                     ? static_cast<int>(ceil(config::JOYSTICK_ACCEL_MULTIPLIER))
+                     : 1;
+      updateTimeEditing(timeCursor_, direction * step);
+    }
+    if (fabs(x) > 0.5f) {
+      timeCursor_ = (x > 0) ? (timeCursor_ + 1) : (timeCursor_ == 0 ? 0 : timeCursor_ - 1);
+      if (timeCursor_ > 3) {
+        setScreen(Screen::DateSetting);
+      }
+    }
+  } else if (screen_ == Screen::DateSetting) {
+    int direction = 0;
+    if (y > 0.2f) direction = 1;
+    if (y < -0.2f) direction = -1;
+    if (direction != 0) {
+      int step = (fabs(y) > config::JOYSTICK_ACCEL_THRESHOLD)
+                     ? static_cast<int>(ceil(config::JOYSTICK_ACCEL_MULTIPLIER))
+                     : 1;
+      updateDateEditing(dateField_, direction * step);
+    }
+    if (fabs(x) > 0.5f) {
+      dateField_ = (x > 0) ? (dateField_ + 1) : (dateField_ == 0 ? 0 : dateField_ - 1);
+      if (dateField_ > 2) {
+        setScreen(Screen::Main);
+      }
+    }
+  } else if (screen_ == Screen::Calibration) {
+    int direction = 0;
+    if (y > 0.1f) direction = 1;
+    if (y < -0.1f) direction = -1;
+    if (direction != 0) {
+      float accel = (fabs(y) > config::JOYSTICK_ACCEL_THRESHOLD)
+                        ? config::JOYSTICK_ACCEL_MULTIPLIER
+                        : 1.0f;
+      calibrationInput_ += direction * accel;
+    }
+    if (calibrationInput_ < 0) {
+      calibrationInput_ = 0;
+    }
+  } else {
+    if (x > 0.5f) {
+      if (screen_ == Screen::Main) {
+        setScreen(Screen::LevelStats);
+      } else if (screen_ == Screen::LevelStats) {
+        setScreen(Screen::FlowStats);
+      } else if (screen_ == Screen::FlowStats) {
+        setScreen(Screen::Main);
+      }
+    } else if (x < -0.5f) {
+      if (screen_ == Screen::Main) {
+        setScreen(Screen::FlowStats);
+      } else if (screen_ == Screen::LevelStats) {
+        setScreen(Screen::Main);
+      } else if (screen_ == Screen::FlowStats) {
+        setScreen(Screen::LevelStats);
+      }
+    }
+  }
+}
+
+void UIManager::handleButtons(bool button1Pressed, bool button2Pressed, bool bothHeld) {
+  if (bothHeld) {
+    setScreen(Screen::Calibration);
+    calibrationRequested_ = true;
+    return;
+  }
+  if (screen_ == Screen::Calibration) {
+    if (!button1Pressed && !button2Pressed) {
+      setScreen(Screen::Main);
+    }
+    return;
+  }
+}
+
+void UIManager::setCalibrationValue(float value) { calibrationInput_ = value; }
+
+void UIManager::resetCalibrationRequest() { calibrationRequested_ = false; }
+
+void UIManager::setTimeSetting(struct tm timeinfo) {
+  editableTime_ = timeinfo;
+  timeCursor_ = 0;
+  dateField_ = 0;
+}
+
+void UIManager::commitTime(struct tm timeinfo) { editableTime_ = timeinfo; }
+
+void UIManager::updateTimeEditing(int digitIndex, int delta) {
+  if (digitIndex < 0 || digitIndex > 3) {
+    return;
+  }
+  int values[4] = {editableTime_.tm_hour / 10, editableTime_.tm_hour % 10,
+                   editableTime_.tm_min / 10, editableTime_.tm_min % 10};
+  values[digitIndex] += delta;
+  if (values[digitIndex] < 0) {
+    values[digitIndex] = 9;
+  } else if (values[digitIndex] > 9) {
+    values[digitIndex] = 0;
+  }
+  int newHour = values[0] * 10 + values[1];
+  int newMinute = values[2] * 10 + values[3];
+  if (newHour >= 24) {
+    newHour = 0;
+  }
+  if (newMinute >= 60) {
+    newMinute = 0;
+  }
+  editableTime_.tm_hour = newHour;
+  editableTime_.tm_min = newMinute;
+}
+
+void UIManager::updateDateEditing(int fieldIndex, int delta) {
+  if (fieldIndex == 0) {
+    editableTime_.tm_mday += delta;
+    if (editableTime_.tm_mday < 1) editableTime_.tm_mday = 31;
+    if (editableTime_.tm_mday > 31) editableTime_.tm_mday = 1;
+  } else if (fieldIndex == 1) {
+    editableTime_.tm_mon += delta;
+    if (editableTime_.tm_mon < 0) editableTime_.tm_mon = 11;
+    if (editableTime_.tm_mon > 11) editableTime_.tm_mon = 0;
+  } else if (fieldIndex == 2) {
+    editableTime_.tm_year += delta;
+    if (editableTime_.tm_year < 120) editableTime_.tm_year = 120;
+    if (editableTime_.tm_year > 200) editableTime_.tm_year = 200;
+  }
+}
+

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,48 +1,392 @@
 #include <Arduino.h>
+#include <Bounce2.h>
+#include <LiquidCrystal_I2C.h>
+#include <SdFat.h>
+#include <SPI.h>
+#include <algorithm>
+#include <array>
+#include <freertos/FreeRTOS.h>
+#include <freertos/queue.h>
+#include <freertos/task.h>
+#include <sys/time.h>
+#include <time.h>
 
-// --- Ayarlar ---
-#define FLOW_PIN 25          // Direnç bölücünün ESP32'ye geldiği pin
-#define TIMEOUT_US 500000UL  // 500 ms; gerekirse 1_000_000 yap
+#include "Config.h"
+#include "Conversions.h"
+#include "LoggingManager.h"
+#include "RunningStatistics.h"
+#include "SensorData.h"
+#include "UIManager.h"
+
+// Uncomment to enable verbose debug serial output.
+//#define DEBUG_PROJECT_KALKAN
+
+#ifdef DEBUG_PROJECT_KALKAN
+static constexpr bool kDebug = true;
+#else
+static constexpr bool kDebug = false;
+#endif
+
+namespace {
+
+LiquidCrystal_I2C lcd(config::LCD_ADDR, config::LCD_COLS, config::LCD_ROWS);
+UIManager ui(lcd);
+SdFat sd;
+LoggingManager logger(sd);
+
+QueueHandle_t sensorQueue = nullptr;
+QueueHandle_t commandQueue = nullptr;
+SemaphoreHandle_t calibrationMutex = nullptr;
+
+CalibrationFactors calibrationFactors;
+
+volatile uint32_t gPulseCount = 0;
+volatile uint32_t gLastPulseMicros = 0;
+volatile uint32_t gPrevPulseMicros = 0;
+
+struct SensorMessage {
+  SensorSnapshot snapshot;
+  AnalyticsState analytics;
+};
+
+enum class UICommandType : uint8_t {
+  TriggerEvent,
+  SetCalibration,
+};
+
+struct UICommand {
+  UICommandType type;
+  float value;
+};
+
+void IRAM_ATTR onFlowPulse() {
+  uint32_t now = micros();
+  gPulseCount++;
+  gPrevPulseMicros = gLastPulseMicros;
+  gLastPulseMicros = now;
+}
+
+float readLevelVoltage() {
+  std::array<uint16_t, config::ANALOG_OVERSAMPLE> samples{};
+  for (size_t i = 0; i < samples.size(); ++i) {
+    samples[i] = analogRead(config::LEVEL_SENSOR_PIN);
+    delayMicroseconds(200);
+  }
+  std::array<uint16_t, config::ANALOG_OVERSAMPLE> sorted = samples;
+  std::sort(sorted.begin(), sorted.end());
+  uint32_t sum = 0;
+  for (size_t i = 1; i + 1 < sorted.size(); ++i) {
+    sum += sorted[i];
+  }
+  float average = static_cast<float>(sum) / static_cast<float>(sorted.size() - 2);
+  float voltage = (average / 4095.0f) * 3.3f;
+  return voltage;
+}
+
+String iso8601FromTime(time_t now) {
+  struct tm timeinfo;
+  gmtime_r(&now, &timeinfo);
+  char buffer[32];
+  strftime(buffer, sizeof(buffer), "%Y-%m-%dT%H:%M:%SZ", &timeinfo);
+  return String(buffer);
+}
+
+void processUICommand(const UICommand& command, const LogRecord& latestRecord) {
+  switch (command.type) {
+    case UICommandType::TriggerEvent:
+      logger.triggerEvent(latestRecord);
+      break;
+    case UICommandType::SetCalibration: {
+      CalibrationFactors copy = calibrationFactors;
+      copy.referenceHeightCm = command.value;
+      if (xSemaphoreTake(calibrationMutex, pdMS_TO_TICKS(10)) == pdTRUE) {
+        calibrationFactors = copy;
+        xSemaphoreGive(calibrationMutex);
+      }
+      break;
+    }
+  }
+}
+
+float readJoystickAxis(gpio_num_t pin) {
+  int raw = analogRead(pin);
+  int centered = raw - config::JOYSTICK_MAX / 2;
+  if (abs(centered) < config::JOYSTICK_DEADBAND) {
+    return 0.0f;
+  }
+  float normalized = static_cast<float>(centered) / (config::JOYSTICK_MAX / 2.0f);
+  normalized = std::max(-1.0f, std::min(1.0f, normalized));
+  return normalized;
+}
+
+void configureAdc() {
+  analogReadResolution(12);
+  analogSetPinAttenuation(config::LEVEL_SENSOR_PIN, ADC_11db);
+  analogSetPinAttenuation(config::JOYSTICK_X_PIN, ADC_11db);
+  analogSetPinAttenuation(config::JOYSTICK_Y_PIN, ADC_11db);
+}
+
+}  // namespace
+
+void sensorTask(void* pvParameters) {
+  configureAdc();
+
+  RunningStatistics<config::FLOW_STATS_WINDOW> flowStats;
+  RunningStatistics<config::LEVEL_STATS_WINDOW> levelStats;
+  float emaVoltage = 0.0f;
+  bool emaInitialized = false;
+
+  uint32_t lastPulseCount = 0;
+  uint32_t windowPulseCount = 0;
+  uint32_t windowStartMs = millis();
+  LogRecord latestRecord{};
+
+  logger.begin();
+
+  for (;;) {
+    uint32_t loopStartMs = millis();
+
+    uint32_t currentPulseCount;
+    taskENTER_CRITICAL();
+    currentPulseCount = gPulseCount;
+    taskEXIT_CRITICAL();
+
+    uint32_t delta = currentPulseCount - lastPulseCount;
+    lastPulseCount = currentPulseCount;
+    windowPulseCount += delta;
+    uint32_t elapsedWindowMs = loopStartMs - windowStartMs;
+    float frequencyHz = 0.0f;
+    if (elapsedWindowMs >= config::FLOW_WINDOW_MS) {
+      frequencyHz = (windowPulseCount * 1000.0f) / static_cast<float>(elapsedWindowMs);
+      windowPulseCount = 0;
+      windowStartMs = loopStartMs;
+    }
+
+    float flowLps = convertPulseToFlowLps(frequencyHz);
+    flowStats.push(flowLps);
+
+    float voltage = readLevelVoltage();
+    if (!emaInitialized) {
+      emaVoltage = voltage;
+      emaInitialized = true;
+    } else {
+      emaVoltage = emaVoltage + config::ANALOG_ALPHA * (voltage - emaVoltage);
+    }
+
+    CalibrationFactors calibrationCopy;
+    if (xSemaphoreTake(calibrationMutex, pdMS_TO_TICKS(10)) == pdTRUE) {
+      calibrationCopy = calibrationFactors;
+      xSemaphoreGive(calibrationMutex);
+    } else {
+      calibrationCopy = calibrationFactors;
+    }
+
+    float heightCm = convertVoltageToHeight(emaVoltage, calibrationCopy);
+    levelStats.push(heightCm);
+
+    FlowMetrics flowMetrics;
+    flowMetrics.instantaneousLps = flowLps;
+    flowMetrics.baselineLps = flowStats.percentile(0.9f);
+    flowMetrics.minimumHealthyLps = flowStats.percentile(0.1f);
+    flowMetrics.meanLps = flowStats.mean();
+    flowMetrics.medianLps = flowStats.median();
+    if (flowMetrics.baselineLps > 0.01f) {
+      flowMetrics.differencePct =
+          ((flowMetrics.instantaneousLps - flowMetrics.baselineLps) / flowMetrics.baselineLps) * 100.0f;
+    } else {
+      flowMetrics.differencePct = 0.0f;
+    }
+
+    LevelMetrics levelMetrics;
+    levelMetrics.instantaneousCm = heightCm;
+    levelMetrics.baselineCm = levelStats.percentile(0.1f);
+    levelMetrics.fullTankCm = levelStats.percentile(0.9f);
+    if (levelMetrics.fullTankCm > 0.01f) {
+      levelMetrics.differencePct =
+          ((levelMetrics.instantaneousCm - levelMetrics.fullTankCm) / levelMetrics.fullTankCm) * 100.0f;
+    } else {
+      levelMetrics.differencePct = 0.0f;
+    }
+    float meanLevel = levelStats.mean();
+    float stdLevel = levelStats.stddev();
+    if (meanLevel > 0.01f) {
+      levelMetrics.noiseMetric = (stdLevel / meanLevel) * 100.0f;
+    } else {
+      levelMetrics.noiseMetric = 0.0f;
+    }
+
+    AnalyticsState analytics;
+    analytics.flow = flowMetrics;
+    analytics.level = levelMetrics;
+    analytics.flowStats.minValue = flowStats.minimum();
+    analytics.flowStats.maxValue = flowStats.maximum();
+    analytics.flowStats.meanValue = flowStats.mean();
+    analytics.flowStats.medianValue = flowStats.median();
+    analytics.flowStats.stddevValue = flowStats.stddev();
+    analytics.levelStats.minValue = levelStats.minimum();
+    analytics.levelStats.maxValue = levelStats.maximum();
+    analytics.levelStats.meanValue = levelStats.mean();
+    analytics.levelStats.medianValue = levelStats.median();
+    analytics.levelStats.stddevValue = levelStats.stddev();
+
+    SensorSnapshot snapshot;
+    snapshot.timestamp = time(nullptr);
+    snapshot.pulseCount = currentPulseCount;
+    snapshot.pulseFrequencyHz = frequencyHz;
+    snapshot.levelVoltage = emaVoltage;
+    snapshot.flow = flowMetrics;
+    snapshot.level = levelMetrics;
+
+    latestRecord.timestamp = snapshot.timestamp;
+    latestRecord.iso8601 = iso8601FromTime(snapshot.timestamp);
+    latestRecord.pulseCount = snapshot.pulseCount;
+    latestRecord.pulseFrequency = snapshot.pulseFrequencyHz;
+    latestRecord.levelVoltage = snapshot.levelVoltage;
+    latestRecord.flow = snapshot.flow;
+    latestRecord.level = snapshot.level;
+
+    logger.update(snapshot.timestamp, latestRecord);
+    logger.loop();
+
+    SensorMessage message{snapshot, analytics};
+    xQueueOverwrite(sensorQueue, &message);
+
+    UICommand command;
+    while (xQueueReceive(commandQueue, &command, 0) == pdTRUE) {
+      processUICommand(command, latestRecord);
+    }
+
+    if (kDebug) {
+      Serial.print("Flow L/s: ");
+      Serial.print(flowLps, 3);
+      Serial.print(" Voltage: ");
+      Serial.print(voltage, 3);
+      Serial.print(" Height: ");
+      Serial.print(heightCm, 2);
+      Serial.print(" Noise%: ");
+      Serial.println(levelMetrics.noiseMetric, 2);
+    }
+
+    vTaskDelay(config::SENSOR_TASK_DELAY);
+  }
+}
+
+void uiTask(void* pvParameters) {
+  Bounce button1;
+  Bounce button2;
+  button1.attach(static_cast<uint8_t>(config::BUTTON1_PIN), INPUT_PULLUP);
+  button2.attach(static_cast<uint8_t>(config::BUTTON2_PIN), INPUT_PULLUP);
+  button1.interval(config::BUTTON_DEBOUNCE_MS);
+  button2.interval(config::BUTTON_DEBOUNCE_MS);
+
+  ui.begin();
+
+  struct tm initialTime = {};
+  time_t now;
+  time(&now);
+  localtime_r(&now, &initialTime);
+  if (initialTime.tm_year + 1900 < 2023) {
+    initialTime.tm_year = 125;  // 2025 baseline
+    initialTime.tm_mon = 6;
+    initialTime.tm_mday = 6;
+    initialTime.tm_hour = 12;
+    initialTime.tm_min = 0;
+  }
+  ui.setTimeSetting(initialTime);
+
+  SensorMessage lastMessage{};
+  bool haveMessage = false;
+  bool timeConfigured = false;
+  uint32_t bothPressedStart = 0;
+
+  for (;;) {
+    SensorMessage message;
+    if (xQueueReceive(sensorQueue, &message, 0) == pdTRUE) {
+      lastMessage = message;
+      haveMessage = true;
+    }
+
+    button1.update();
+    button2.update();
+    bool b1 = !button1.read();
+    bool b2 = !button2.read();
+
+    if (b1 && b2) {
+      if (bothPressedStart == 0) {
+        bothPressedStart = millis();
+      } else if (millis() - bothPressedStart >= config::BUTTON_HOLD_MS) {
+        if (haveMessage) {
+          ui.setCalibrationValue(lastMessage.snapshot.level.instantaneousCm);
+        }
+        ui.handleButtons(true, true, true);
+      }
+    } else {
+      bothPressedStart = 0;
+      ui.handleButtons(b1, b2, false);
+    }
+
+    if (button1.fell()) {
+      UICommand cmd{UICommandType::TriggerEvent, 0.0f};
+      xQueueSend(commandQueue, &cmd, 0);
+    }
+
+    if (ui.currentScreen() == UIManager::Screen::Calibration && !b1 && !b2 && ui.calibrationRequested()) {
+      UICommand cmd{UICommandType::SetCalibration, ui.calibrationInputValue()};
+      xQueueSend(commandQueue, &cmd, 0);
+      ui.resetCalibrationRequest();
+    }
+
+    float joyX = readJoystickAxis(config::JOYSTICK_X_PIN);
+    float joyY = readJoystickAxis(config::JOYSTICK_Y_PIN);
+    ui.handleJoystick(joyX, joyY);
+
+    if (haveMessage) {
+      ui.update(lastMessage.analytics, lastMessage.snapshot);
+    } else {
+      SensorSnapshot emptySnapshot;
+      AnalyticsState emptyAnalytics;
+      ui.update(emptyAnalytics, emptySnapshot);
+    }
+
+    if (!timeConfigured && ui.currentScreen() == UIManager::Screen::Main) {
+      struct tm edited = ui.editableTime();
+      edited.tm_sec = 0;
+      edited.tm_isdst = -1;
+      time_t newTime = mktime(&edited);
+      struct timeval tv;
+      tv.tv_sec = newTime;
+      tv.tv_usec = 0;
+      settimeofday(&tv, nullptr);
+      timeConfigured = true;
+    }
+
+    vTaskDelay(pdMS_TO_TICKS(50));
+  }
+}
 
 void setup() {
-  Serial.begin(9600);
-  delay(200);
+  if (kDebug) {
+    Serial.begin(115200);
+    while (!Serial) {
+      delay(10);
+    }
+  }
 
-  // Direnç bölücü kullanıyorsan INPUT (iç pullup/down kapalı)
-  pinMode(FLOW_PIN, INPUT);
+  pinMode(config::FLOW_SENSOR_PIN, INPUT);
+  pinMode(config::LEVEL_SENSOR_PIN, INPUT);
+  pinMode(config::JOYSTICK_X_PIN, INPUT);
+  pinMode(config::JOYSTICK_Y_PIN, INPUT);
+  attachInterrupt(digitalPinToInterrupt(config::FLOW_SENSOR_PIN), onFlowPulse, RISING);
 
-  Serial.println("Akis sensoru PULSE TEST (interruptsuz, pulseIn ile)");
-  Serial.println("Rapor: tHIGH(us), tLOW(us), freq(Hz), duty(%)");
+  sensorQueue = xQueueCreate(1, sizeof(SensorMessage));
+  commandQueue = xQueueCreate(5, sizeof(UICommand));
+  calibrationMutex = xSemaphoreCreateMutex();
+
+  xTaskCreatePinnedToCore(sensorTask, "SensorTask", 8192, nullptr, 2, nullptr, 0);
+  xTaskCreatePinnedToCore(uiTask, "UITask", 8192, nullptr, 1, nullptr, 1);
 }
 
 void loop() {
-  // Önce HIGH süresi, sonra LOW süresi ölçülür
-  // Not: pulseIn, belirtilen seviyeye GELEN kenarı bekler, sonra süresini ölçer.
-  unsigned long tHigh = pulseIn(FLOW_PIN, HIGH, TIMEOUT_US);
-  unsigned long tLow  = pulseIn(FLOW_PIN, LOW,  TIMEOUT_US);
-
-  if (tHigh == 0 && tLow == 0) {
-    // Zaman asimi: veri yakalanamadi
-    Serial.println("Pulse yok (timeout). Hat/besleme/bölücü/ground kontrol et.");
-  } else {
-    // Birini bulduysak digerini de bulmaya calis
-    // (bazen ilk okuma 0 olabilir; tekrar denemek istersen burada ikinci ölçüm ekleyebilirsin)
-
-    // Period ve frekans
-    double period = (double)tHigh + (double)tLow;   // us
-    double freqHz = (period > 0.0) ? (1000000.0 / period) : 0.0;
-    double duty   = (period > 0.0) ? (100.0 * (double)tHigh / period) : 0.0;
-
-    Serial.print("tH=");
-    Serial.print(tHigh);
-    Serial.print("us, tL=");
-    Serial.print(tLow);
-    Serial.print("us, f=");
-    Serial.print(freqHz, 2);
-    Serial.print(" Hz, duty=");
-    Serial.print(duty, 1);
-    Serial.println("%");
-  }
-
-  delay(250);  // 4 Hz rapor
+  vTaskDelay(pdMS_TO_TICKS(1000));
 }
+

--- a/test/test_conversion.cpp
+++ b/test/test_conversion.cpp
@@ -1,0 +1,32 @@
+#include <Arduino.h>
+#include <unity.h>
+
+#include "Config.h"
+#include "Conversions.h"
+
+void test_flow_conversion() {
+  TEST_ASSERT_FLOAT_WITHIN(0.0001f, 1.0f, convertPulseToFlowLps(12.0f));
+  TEST_ASSERT_FLOAT_WITHIN(0.0001f, 0.5f, convertPulseToFlowLps(6.0f));
+}
+
+void test_voltage_to_height() {
+  CalibrationFactors cal;
+  cal.vMin = 0.48f;
+  cal.vMax = 2.4f;
+  cal.referenceHeightCm = 500.0f;
+  cal.densityRatio = 1.0f;
+
+  float midVoltage = (cal.vMin + cal.vMax) / 2.0f;
+  float height = convertVoltageToHeight(midVoltage, cal);
+  TEST_ASSERT_FLOAT_WITHIN(0.5f, 250.0f, height);
+}
+
+void setup() {
+  UNITY_BEGIN();
+  RUN_TEST(test_flow_conversion);
+  RUN_TEST(test_voltage_to_height);
+  UNITY_END();
+}
+
+void loop() {}
+


### PR DESCRIPTION
## Summary
- replace the prototype sketch with a dual-core Project Kalkan implementation that samples the flow and level sensors, performs rolling analytics, and feeds the LCD UI via queues
- add SD card logging with daily files, 20-minute RAM buffers, and event snapshot support driven from the UI buttons
- introduce reusable configuration, statistics, conversion helpers, and a unit test harness while updating PlatformIO dependencies

## Testing
- `pio test -e esp32dev` *(fails: PlatformIO CLI not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6d16b84c4832085c5060a4461e844