### PR TITLE
Log flow pulse periods in CSV output

### DIFF
--- a/lib/ConfigService/ConfigService.h
+++ b/lib/ConfigService/ConfigService.h
@@ -1,27 +1,204 @@
 #pragma once
 
 #include <Arduino.h>
+#include <Preferences.h>
+#include <algorithm>
+#include <cmath>
 
 class ConfigService {
   public:
-    void begin() {}
+    void begin() {
+        if (_prefs.begin("wfpress", false)) {
+            _prefsInitialized = true;
+            loadFromStorage();
+        }
+    }
+
+    void end() {
+        if (_prefsInitialized) {
+            _prefs.end();
+            _prefsInitialized = false;
+        }
+    }
 
     uint32_t sensorIntervalMs() const { return _sensorIntervalMs; }
-    void setSensorIntervalMs(uint32_t value) { _sensorIntervalMs = value; }
+    void setSensorIntervalMs(uint32_t value) {
+        value = clampInterval(value, 200, 60000);
+        if (value != _sensorIntervalMs) {
+            _sensorIntervalMs = value;
+            persist();
+        }
+    }
 
     uint32_t loggingIntervalMs() const { return _loggingIntervalMs; }
-    void setLoggingIntervalMs(uint32_t value) { _loggingIntervalMs = value; }
+    void setLoggingIntervalMs(uint32_t value) {
+        value = clampInterval(value, 500, 60000);
+        if (value != _loggingIntervalMs) {
+            _loggingIntervalMs = value;
+            persist();
+        }
+    }
 
     float densityFactor() const { return _densityFactor; }
-    void setDensityFactor(float value) { _densityFactor = value <= 0.0f ? 1.0f : value; }
+    void setDensityFactor(float value) {
+        value = (value <= 0.0f) ? 1.0f : value;
+        if (fabsf(_densityFactor - value) > 0.0001f) {
+            _densityFactor = value;
+            persist();
+        }
+    }
 
     uint8_t levelOversampleCount() const { return _oversampleCount; }
-    void setLevelOversampleCount(uint8_t count) { _oversampleCount = count; }
+    void setLevelOversampleCount(uint8_t count) {
+        count = std::max<uint8_t>(3, std::min<uint8_t>(64, count));
+        if (count != _oversampleCount) {
+            _oversampleCount = count;
+            persist();
+        }
+    }
+
+    float zeroCurrentMa() const { return _zeroCurrentMa; }
+    void setZeroCurrentMa(float value) {
+        value = constrainFloat(value, 0.0f, 10.0f);
+        if (fabsf(_zeroCurrentMa - value) > 0.0001f) {
+            _zeroCurrentMa = value;
+            persist();
+        }
+    }
+
+    float fullScaleCurrentMa() const { return _fullScaleCurrentMa; }
+    void setFullScaleCurrentMa(float value) {
+        value = constrainFloat(value, 12.0f, 30.0f);
+        if (fabsf(_fullScaleCurrentMa - value) > 0.0001f) {
+            _fullScaleCurrentMa = value;
+            persist();
+        }
+    }
+
+    float fullScaleHeightMm() const { return _fullScaleHeightMm; }
+    void setFullScaleHeightMm(float value) {
+        value = constrainFloat(value, 500.0f, 10000.0f);
+        if (fabsf(_fullScaleHeightMm - value) > 0.01f) {
+            _fullScaleHeightMm = value;
+            persist();
+        }
+    }
+
+    float pulsesPerLiter() const { return _pulsesPerLiter; }
+    void setPulsesPerLiter(float value) {
+        value = constrainFloat(value, 1.0f, 200.0f);
+        if (fabsf(_pulsesPerLiter - value) > 0.0001f) {
+            _pulsesPerLiter = value;
+            persist();
+        }
+    }
+
+    float currentSenseResistorOhms() const { return _senseResistorOhms; }
+    void setCurrentSenseResistorOhms(float value) {
+        value = constrainFloat(value, 10.0f, 1000.0f);
+        if (fabsf(_senseResistorOhms - value) > 0.01f) {
+            _senseResistorOhms = value;
+            persist();
+        }
+    }
+
+    float currentSenseGain() const { return _senseGain; }
+    void setCurrentSenseGain(float value) {
+        value = constrainFloat(value, 0.1f, 10.0f);
+        if (fabsf(_senseGain - value) > 0.0001f) {
+            _senseGain = value;
+            persist();
+        }
+    }
+
+    float alphaGain() const { return _alphaGain; }
+    void setAlphaGain(float value) {
+        value = constrainFloat(value, 0.01f, 1.0f);
+        if (fabsf(_alphaGain - value) > 0.0001f) {
+            _alphaGain = value;
+            persist();
+        }
+    }
+
+    float betaGain() const { return _betaGain; }
+    void setBetaGain(float value) {
+        value = constrainFloat(value, 0.001f, 1.0f);
+        if (fabsf(_betaGain - value) > 0.0001f) {
+            _betaGain = value;
+            persist();
+        }
+    }
 
   private:
+    uint32_t clampInterval(uint32_t value, uint32_t minValue, uint32_t maxValue) const {
+        if (value < minValue) {
+            return minValue;
+        }
+        if (value > maxValue) {
+            return maxValue;
+        }
+        return value;
+    }
+
+    float constrainFloat(float value, float minValue, float maxValue) const {
+        if (value < minValue) {
+            return minValue;
+        }
+        if (value > maxValue) {
+            return maxValue;
+        }
+        return value;
+    }
+
+    void loadFromStorage() {
+        if (!_prefsInitialized) {
+            return;
+        }
+        _sensorIntervalMs = _prefs.getULong("sens_int", _sensorIntervalMs);
+        _loggingIntervalMs = _prefs.getULong("log_int", _loggingIntervalMs);
+        _densityFactor = _prefs.getFloat("density", _densityFactor);
+        _oversampleCount = static_cast<uint8_t>(_prefs.getUInt("os_cnt", _oversampleCount));
+        _zeroCurrentMa = _prefs.getFloat("zero_ma", _zeroCurrentMa);
+        _fullScaleCurrentMa = _prefs.getFloat("full_ma", _fullScaleCurrentMa);
+        _fullScaleHeightMm = _prefs.getFloat("full_mm", _fullScaleHeightMm);
+        _pulsesPerLiter = _prefs.getFloat("ppl", _pulsesPerLiter);
+        _senseResistorOhms = _prefs.getFloat("sense_r", _senseResistorOhms);
+        _senseGain = _prefs.getFloat("sense_g", _senseGain);
+        _alphaGain = _prefs.getFloat("alpha", _alphaGain);
+        _betaGain = _prefs.getFloat("beta", _betaGain);
+    }
+
+    void persist() {
+        if (!_prefsInitialized) {
+            return;
+        }
+        _prefs.putULong("sens_int", _sensorIntervalMs);
+        _prefs.putULong("log_int", _loggingIntervalMs);
+        _prefs.putFloat("density", _densityFactor);
+        _prefs.putUInt("os_cnt", _oversampleCount);
+        _prefs.putFloat("zero_ma", _zeroCurrentMa);
+        _prefs.putFloat("full_ma", _fullScaleCurrentMa);
+        _prefs.putFloat("full_mm", _fullScaleHeightMm);
+        _prefs.putFloat("ppl", _pulsesPerLiter);
+        _prefs.putFloat("sense_r", _senseResistorOhms);
+        _prefs.putFloat("sense_g", _senseGain);
+        _prefs.putFloat("alpha", _alphaGain);
+        _prefs.putFloat("beta", _betaGain);
+    }
+
+    Preferences _prefs;
+    bool _prefsInitialized = false;
     uint32_t _sensorIntervalMs = 1000;
     uint32_t _loggingIntervalMs = 1000;
     float _densityFactor = 1.0f;
     uint8_t _oversampleCount = 10;
+    float _zeroCurrentMa = 4.0f;
+    float _fullScaleCurrentMa = 20.0f;
+    float _fullScaleHeightMm = 5000.0f;
+    float _pulsesPerLiter = 12.0f;
+    float _senseResistorOhms = 150.0f;
+    float _senseGain = 1.0f;
+    float _alphaGain = 0.4f;
+    float _betaGain = 0.02f;
 };
 

--- a/lib/FlowSensor/FlowSensor.cpp
+++ b/lib/FlowSensor/FlowSensor.cpp
@@ -1,23 +1,56 @@
 #include "FlowSensor.h"
 
+#include <cstring>
+
 #include <driver/gpio.h>
 
 namespace {
 portMUX_TYPE flowSensorMux = portMUX_INITIALIZER_UNLOCKED;
 }
 
-FlowSensor* FlowSensor::instance = nullptr;
+FlowSensor::FlowSensor()
+    : _pin(0),
+      _unit(PCNT_UNIT_0),
+      _pulseCount(0),
+      _lastPeriodMicros(0),
+      _lastTimestampMicros(0),
+      _periodCount(0),
+      _periodIndex(0) {
+    memset((void*)_periodHistory, 0, sizeof(_periodHistory));
+}
 
-FlowSensor::FlowSensor() : _pin(0), _pulseCount(0), _lastPeriodMicros(0), _lastTimestampMicros(0) {}
-
-void FlowSensor::begin(uint8_t pin) {
+void FlowSensor::begin(uint8_t pin, pcnt_unit_t unit) {
     _pin = pin;
+    _unit = unit;
+
     pinMode(_pin, INPUT);
+
+    pcnt_config_t pcntConfig = {};
+    pcntConfig.pulse_gpio_num = static_cast<gpio_num_t>(_pin);
+    pcntConfig.ctrl_gpio_num = PCNT_PIN_NOT_USED;
+    pcntConfig.unit = _unit;
+    pcntConfig.channel = PCNT_CHANNEL_0;
+    pcntConfig.counter_h_lim = 32000;
+    pcntConfig.counter_l_lim = -1;
+    pcntConfig.pos_mode = PCNT_COUNT_INC;
+    pcntConfig.neg_mode = PCNT_COUNT_DIS;
+    pcntConfig.lctrl_mode = PCNT_MODE_KEEP;
+    pcntConfig.hctrl_mode = PCNT_MODE_KEEP;
+    pcnt_unit_config(&pcntConfig);
+
+    pcnt_set_filter_value(_unit, 1000);
+    pcnt_filter_enable(_unit);
+    pcnt_counter_pause(_unit);
+    pcnt_counter_clear(_unit);
+    pcnt_counter_resume(_unit);
+
     _pulseCount = 0;
     _lastPeriodMicros = 0;
     _lastTimestampMicros = micros();
-    instance = this;
-    attachInterrupt(digitalPinToInterrupt(_pin), FlowSensor::isrHandler, RISING);
+    _periodCount = 0;
+    _periodIndex = 0;
+
+    attachInterruptArg(digitalPinToInterrupt(_pin), FlowSensor::isrHandler, this, RISING);
 }
 
 void FlowSensor::reset() {
@@ -25,29 +58,64 @@ void FlowSensor::reset() {
     _pulseCount = 0;
     _lastPeriodMicros = 0;
     _lastTimestampMicros = micros();
+    _periodCount = 0;
+    _periodIndex = 0;
+    memset((void*)_periodHistory, 0, sizeof(_periodHistory));
+    pcnt_counter_clear(_unit);
     portEXIT_CRITICAL(&flowSensorMux);
 }
 
 FlowSensor::Snapshot FlowSensor::takeSnapshot() const {
     Snapshot snap;
+    updateFromCounter();
+
     portENTER_CRITICAL(&flowSensorMux);
     snap.totalPulses = _pulseCount;
     snap.lastPeriodMicros = _lastPeriodMicros;
     snap.lastTimestampMicros = _lastTimestampMicros;
+    snap.periodCount = _periodCount;
+    size_t count = _periodCount;
+    for (size_t i = 0; i < count; ++i) {
+        size_t index = (_periodIndex + PERIOD_HISTORY - count + i) % PERIOD_HISTORY;
+        snap.recentPeriods[i] = _periodHistory[index];
+    }
+    for (size_t i = count; i < PERIOD_HISTORY; ++i) {
+        snap.recentPeriods[i] = 0;
+    }
     portEXIT_CRITICAL(&flowSensorMux);
     return snap;
 }
 
-void IRAM_ATTR FlowSensor::isrHandler() {
-    if (instance != nullptr) {
-        instance->handlePulse();
+void FlowSensor::updateFromCounter() const {
+    int16_t current = 0;
+    pcnt_get_counter_value(_unit, &current);
+    if (current != 0) {
+        pcnt_counter_clear(_unit);
+        portENTER_CRITICAL(&flowSensorMux);
+        if (current > 0) {
+            _pulseCount += static_cast<uint64_t>(current);
+        }
+        portEXIT_CRITICAL(&flowSensorMux);
     }
+}
+
+void IRAM_ATTR FlowSensor::isrHandler(void* arg) {
+    if (arg == nullptr) {
+        return;
+    }
+    static_cast<FlowSensor*>(arg)->handlePulse();
 }
 
 void IRAM_ATTR FlowSensor::handlePulse() {
     uint32_t now = micros();
-    _pulseCount++;
+    portENTER_CRITICAL_ISR(&flowSensorMux);
     _lastPeriodMicros = now - _lastTimestampMicros;
     _lastTimestampMicros = now;
+    _periodHistory[_periodIndex] = _lastPeriodMicros;
+    _periodIndex = (_periodIndex + 1) % PERIOD_HISTORY;
+    if (_periodCount < PERIOD_HISTORY) {
+        _periodCount++;
+    }
+    portEXIT_CRITICAL_ISR(&flowSensorMux);
 }
 

--- a/lib/FlowSensor/FlowSensor.h
+++ b/lib/FlowSensor/FlowSensor.h
@@ -1,31 +1,41 @@
 #pragma once
 
 #include <Arduino.h>
+#include <driver/pcnt.h>
+#include <array>
+
 #include <../Utils/Utils.h>
 
 class FlowSensor {
   public:
+    static constexpr size_t PERIOD_HISTORY = 16;
+
     struct Snapshot {
-        uint32_t totalPulses;
-        uint32_t lastPeriodMicros;
-        uint32_t lastTimestampMicros;
+        uint64_t totalPulses = 0;
+        uint32_t lastPeriodMicros = 0;
+        uint32_t lastTimestampMicros = 0;
+        std::array<uint32_t, PERIOD_HISTORY> recentPeriods{};
+        size_t periodCount = 0;
     };
 
     FlowSensor();
 
-    void begin(uint8_t pin);
+    void begin(uint8_t pin, pcnt_unit_t unit = PCNT_UNIT_0);
     void reset();
     Snapshot takeSnapshot() const;
 
   private:
-    static void IRAM_ATTR isrHandler();
+    static void IRAM_ATTR isrHandler(void* arg);
     void IRAM_ATTR handlePulse();
-
-    static FlowSensor* instance;
+    void updateFromCounter() const;
 
     uint8_t _pin;
-    volatile uint32_t _pulseCount;
+    pcnt_unit_t _unit;
+    mutable volatile uint64_t _pulseCount;
     volatile uint32_t _lastPeriodMicros;
     volatile uint32_t _lastTimestampMicros;
+    volatile uint32_t _periodHistory[PERIOD_HISTORY];
+    volatile size_t _periodCount;
+    volatile size_t _periodIndex;
 };
 

--- a/lib/LcdUI/LcdUI.h
+++ b/lib/LcdUI/LcdUI.h
@@ -41,6 +41,7 @@ class LcdUI {
         size_t tankOffset = 0;
         unsigned long lastScrollMillis = 0;
         unsigned long scrollInterval = 2000;
+        String cachedLine[2];
     };
 
     struct DateTimeEditor {
@@ -50,8 +51,21 @@ class LcdUI {
     };
 
     struct CalibrationEditor {
+        enum class Item : uint8_t {
+            MeasuredDepth,
+            Density,
+            ZeroCurrent,
+            FullCurrent,
+            FullScaleHeight,
+            PulsesPerLiter,
+            SensorInterval,
+            LoggingInterval,
+            SenseResistor,
+            SenseGain,
+        };
+
+        Item item = Item::MeasuredDepth;
         float value = 0.0f;
-        uint8_t cursorIndex = 0;
         bool active = false;
     };
 
@@ -72,6 +86,11 @@ class LcdUI {
     void handleMainNavigation(float joyX);
     void applyDateTime();
     void updateCalibration(float joyX, float joyY);
+    void selectCalibrationItem(CalibrationEditor::Item item);
+    void commitCalibrationValue();
+    const __FlashStringHelper* calibrationLabel(CalibrationEditor::Item item) const;
+    float calibrationValue(CalibrationEditor::Item item) const;
+    float calibrationStep(CalibrationEditor::Item item) const;
 
     LiquidCrystal_I2C* _lcd = nullptr;
     Buttons* _buttons = nullptr;

--- a/lib/LevelSensor/LevelSensor.h
+++ b/lib/LevelSensor/LevelSensor.h
@@ -12,6 +12,10 @@ class LevelSensor {
     void setOversample(uint8_t count);
     void setEmaAlpha(float alpha);
     void setCalibration(float zeroVoltage, float fullScaleVoltage, float fullScaleHeightCm);
+    void setCalibrationCurrent(float zeroCurrentMa, float fullCurrentMa, float fullScaleHeightMm);
+    void setCurrentSense(float resistorOhms, float gain = 1.0f);
+    void setFilterGains(float alphaGain, float betaGain);
+    void setSampleIntervalMs(uint32_t intervalMs);
     void setDensityFactor(float densityFactor);
     float densityFactor() const { return _densityFactor; }
 
@@ -19,6 +23,8 @@ class LevelSensor {
 
   private:
     float rawToVoltage(uint16_t raw) const;
+    float computeCurrentMilliAmps(float voltage) const;
+    float applyAlphaBetaFilter(float depthMm);
 
     uint8_t _pin;
     uint8_t _oversampleCount;
@@ -28,5 +34,15 @@ class LevelSensor {
     float _fullScaleVoltage;
     float _fullScaleHeightCm;
     float _densityFactor;
+    float _zeroCurrentMa;
+    float _fullCurrentMa;
+    float _fullScaleHeightMm;
+    float _senseResistorOhms;
+    float _senseGain;
+    float _alphaGain;
+    float _betaGain;
+    float _filteredDepthMm;
+    float _velocityMmPerSec;
+    float _sampleIntervalSec;
 };
 

--- a/lib/SdLogger/SdLogger.h
+++ b/lib/SdLogger/SdLogger.h
@@ -29,6 +29,7 @@ class SdLogger {
     void ensureFreeSpace();
     void writeCsvHeader(File32& file);
     void writeLogLine(File32& file, const utils::SensorMetrics& metrics);
+    void trimLogFile(const String& path);
     void startEventFile(time_t timestamp);
     void closeEventFile();
     void flushFiles();


### PR DESCRIPTION
## Summary
- extend the SD logger CSV header with explicit columns for each stored flow pulse period sample
- persist the captured flow period history with each log entry so recent pulse timings can be analyzed offline

## Testing
- pio run

------
https://chatgpt.com/codex/tasks/task_e_68db9c2359b88320b07d3c847be6e586