### PR TITLE
Retry mounting SD card periodically

### DIFF
--- a/lib/LcdUI/LcdUI.cpp
+++ b/lib/LcdUI/LcdUI.cpp
@@ -37,11 +37,47 @@ void LcdUI::setCalibrationCallback(CalibrationCallback cb) {
     _calibrationCallback = cb;
 }
 
+void LcdUI::showTemporaryMessage(const char* msg, uint32_t durationMs) {
+    _overlayText = msg ? msg : "";
+    _overlayEndMs = millis() + durationMs;
+    _overlayActive = true;
+    _overlayCachedLine[0] = "";
+    _overlayCachedLine[1] = "";
+    if (_lcd) {
+        _lcd->clear();
+    }
+    _scroll.cachedLine[0] = "";
+    _scroll.cachedLine[1] = "";
+}
+
 void LcdUI::setMetrics(const utils::SensorMetrics& metrics) {
     _metrics = metrics;
     _hasMetrics = true;
     _lastMetricsTimestamp = metrics.timestamp;
     rebuildScrollBuffers();
+}
+
+String LcdUI::centerText(const String& text) const {
+    String line = text;
+    if (line.length() > 16) {
+        line = line.substring(0, 16);
+    }
+    size_t len = line.length();
+    if (len >= 16) {
+        return line;
+    }
+    size_t totalPad = 16 - len;
+    size_t leftPad = totalPad / 2;
+    size_t rightPad = totalPad - leftPad;
+    String padded;
+    for (size_t i = 0; i < leftPad; ++i) {
+        padded += ' ';
+    }
+    padded += line;
+    for (size_t i = 0; i < rightPad; ++i) {
+        padded += ' ';
+    }
+    return padded;
 }
 
 void LcdUI::ensureCustomGlyphs() {
@@ -106,6 +142,32 @@ void LcdUI::update() {
 
     ensureCustomGlyphs();
     _buttons->update();
+
+    uint32_t now = millis();
+    if (_overlayActive && now >= _overlayEndMs) {
+        _overlayActive = false;
+        _overlayText = "";
+        _overlayCachedLine[0] = "";
+        _overlayCachedLine[1] = "";
+        if (_lcd) {
+            _lcd->clear();
+        }
+        _scroll.cachedLine[0] = "";
+        _scroll.cachedLine[1] = "";
+    }
+
+    if (!_overlayActive && _buttons->bothHeldFor(3000)) {
+        if (_logger) {
+            _logger->pause();
+            _logger->safeRemove();
+        }
+        showTemporaryMessage("SD removed safely", 3000);
+    }
+
+    if (_overlayActive) {
+        renderOverlay();
+        return;
+    }
 
     float joyX = _joystick->readX();
     float joyY = _joystick->readY();
@@ -214,6 +276,46 @@ void LcdUI::renderScrollLine(uint8_t row, const String& label, const std::vector
         _lcd->setCursor(0, row);
         _lcd->print(fullLine);
         _scroll.cachedLine[row] = fullLine;
+    }
+}
+
+void LcdUI::renderOverlay() {
+    if (!_lcd) {
+        return;
+    }
+    String text = _overlayText;
+    String line1;
+    String line2;
+    if (text.length() <= 16) {
+        line1 = centerText(text);
+        line2 = centerText("");
+    } else {
+        int splitIndex = text.lastIndexOf(' ', 16);
+        if (splitIndex < 0) {
+            splitIndex = 16;
+        }
+        line1 = text.substring(0, splitIndex);
+        line1.trim();
+        line2 = text.substring(splitIndex);
+        line2.trim();
+        if (line1.length() > 16) {
+            line1 = line1.substring(0, 16);
+        }
+        if (line2.length() > 16) {
+            line2 = line2.substring(0, 16);
+        }
+        line1 = centerText(line1);
+        line2 = centerText(line2);
+    }
+    if (_overlayCachedLine[0] != line1) {
+        _lcd->setCursor(0, 0);
+        _lcd->print(line1);
+        _overlayCachedLine[0] = line1;
+    }
+    if (_overlayCachedLine[1] != line2) {
+        _lcd->setCursor(0, 1);
+        _lcd->print(line2);
+        _overlayCachedLine[1] = line2;
     }
 }
 

--- a/lib/LcdUI/LcdUI.h
+++ b/lib/LcdUI/LcdUI.h
@@ -20,6 +20,8 @@ class LcdUI {
     void update();
     void setMetrics(const utils::SensorMetrics& metrics);
     void setCalibrationCallback(CalibrationCallback cb);
+    void showTemporaryMessage(const char* msg, uint32_t durationMs);
+    bool isOverlayActive() const { return _overlayActive; }
 
   private:
     enum class ScreenState {
@@ -91,6 +93,8 @@ class LcdUI {
     const __FlashStringHelper* calibrationLabel(CalibrationEditor::Item item) const;
     float calibrationValue(CalibrationEditor::Item item) const;
     float calibrationStep(CalibrationEditor::Item item) const;
+    void renderOverlay();
+    String centerText(const String& text) const;
 
     LiquidCrystal_I2C* _lcd = nullptr;
     Buttons* _buttons = nullptr;
@@ -109,6 +113,10 @@ class LcdUI {
     CalibrationEditor _calEditor;
     time_t _lastMetricsTimestamp = 0;
     unsigned long _lastInputMillis = 0;
+    bool _overlayActive = false;
+    String _overlayText;
+    uint32_t _overlayEndMs = 0;
+    String _overlayCachedLine[2];
 
     uint8_t _glyphMu = 0;
     uint8_t _glyphEta = 1;

--- a/lib/SdLogger/SdLogger.cpp
+++ b/lib/SdLogger/SdLogger.cpp
@@ -14,6 +14,8 @@ bool SdLogger::begin(uint8_t csPin, SPIClass& spi, ConfigService* config) {
     _csPin = csPin;
     _spi = &spi;
     _config = config;
+    _paused = false;
+    _removed = false;
     _spi->begin();
     _sdReady = _sd.begin(SdSpiConfig(_csPin, DEDICATED_SPI, SPI_FULL_SPEED, _spi));
     if (_sdReady) {
@@ -23,6 +25,9 @@ bool SdLogger::begin(uint8_t csPin, SPIClass& spi, ConfigService* config) {
 }
 
 bool SdLogger::ensureMount() {
+    if (_removed) {
+        return false;
+    }
     if (!_sdReady) {
         _sdReady = _sd.begin(SdSpiConfig(_csPin, DEDICATED_SPI, SPI_FULL_SPEED, _spi));
         if (_sdReady) {
@@ -286,6 +291,9 @@ void SdLogger::syncBufferLimit() {
 }
 
 void SdLogger::log(const utils::SensorMetrics& metrics) {
+    if (_removed || _paused) {
+        return;
+    }
     if (!ensureMount()) {
         return;
     }
@@ -353,7 +361,7 @@ void SdLogger::closeEventFile() {
 }
 
 void SdLogger::update() {
-    if (!_sdReady) {
+    if (_removed || !_sdReady) {
         return;
     }
     ensureFreeSpace();
@@ -377,5 +385,52 @@ void SdLogger::flushFiles() {
 
 void SdLogger::requestEventSnapshot() {
     _eventRequested = true;
+}
+
+void SdLogger::resume() {
+    if (_removed) {
+        return;
+    }
+    if (!_sdReady) {
+        if (!ensureMount()) {
+            return;
+        }
+    }
+    _paused = false;
+}
+
+void SdLogger::safeRemove() {
+    if (_removed) {
+        return;
+    }
+    _paused = true;
+    if (!_sdReady) {
+        _currentLogPath = "";
+        _eventRequested = false;
+        _removed = true;
+        powerOffCard();
+        return;
+    }
+
+    flushFiles();
+    if (_eventActive) {
+        closeEventFile();
+    } else if (_eventFile) {
+        _eventFile.sync();
+        _eventFile.close();
+    }
+    if (_logFile) {
+        _logFile.sync();
+        _logFile.close();
+    }
+    _currentLogPath = "";
+    _sdReady = false;
+    _removed = true;
+    _eventRequested = false;
+    powerOffCard();
+}
+
+void SdLogger::powerOffCard() {
+    // Stub for hardware control of SD card power. Implement when wiring is available.
 }
 

--- a/lib/SdLogger/SdLogger.h
+++ b/lib/SdLogger/SdLogger.h
@@ -15,6 +15,11 @@ class SdLogger {
     void log(const utils::SensorMetrics& metrics);
     void requestEventSnapshot();
     bool isReady() const { return _sdReady; }
+    bool isRemoved() const { return _removed; }
+    void pause() { _paused = true; }
+    void resume();
+    void safeRemove();
+    bool isPaused() const { return _paused; }
     bool hasEventActive() const { return _eventActive; }
 
   private:
@@ -34,12 +39,15 @@ class SdLogger {
     void closeEventFile();
     void flushFiles();
     void syncBufferLimit();
+    void powerOffCard();
 
     SdFat32 _sd;
     File32 _logFile;
     File32 _eventFile;
     String _currentLogPath;
     bool _sdReady = false;
+    bool _paused = false;
+    bool _removed = false;
     bool _eventRequested = false;
     bool _eventActive = false;
     time_t _eventEndTime = 0;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -53,6 +53,44 @@ TaskHandle_t g_sensorTaskHandle = nullptr;
 TaskHandle_t g_uiTaskHandle = nullptr;
 TaskHandle_t g_loggerTaskHandle = nullptr;
 
+struct SdAbsentNotifier {
+    bool absent = false;
+    uint32_t nextShowAt = 0;
+    static const uint32_t kIntervalMs = 10000;
+    static const uint32_t kDurationMs = 5000;
+
+    void markAbsent() {
+        if (!absent) {
+            absent = true;
+            nextShowAt = millis();
+        }
+    }
+
+    void markPresent() {
+        absent = false;
+        nextShowAt = 0;
+    }
+
+    void defer() {
+        if (absent) {
+            nextShowAt = millis() + kIntervalMs;
+        }
+    }
+
+    void update(LcdUI& ui) {
+        if (!absent) {
+            return;
+        }
+        uint32_t now = millis();
+        if (!ui.isOverlayActive() && now >= nextShowAt) {
+            ui.showTemporaryMessage("SD card not found", kDurationMs);
+            nextShowAt = now + kIntervalMs;
+        }
+    }
+};
+
+SdAbsentNotifier g_sdNotifier;
+
 void sensorTask(void* parameter);
 void uiTask(void* parameter);
 void loggerTask(void* parameter);
@@ -95,7 +133,10 @@ void setup() {
     g_joystick.begin(PIN_JOYSTICK_X, PIN_JOYSTICK_Y, 0.08f);
 
     g_spi.begin(PIN_SD_SCK, PIN_SD_MISO, PIN_SD_MOSI, PIN_SD_CS);
-    g_logger.begin(PIN_SD_CS, g_spi, &g_config);
+    bool sdReady = g_logger.begin(PIN_SD_CS, g_spi, &g_config);
+    if (!sdReady) {
+        g_sdNotifier.markAbsent();
+    }
 
     g_ui.begin(&g_lcd, &g_buttons, &g_joystick, &g_logger, &g_config);
     g_ui.setCalibrationCallback(applyCalibration);
@@ -298,7 +339,20 @@ void sensorTask(void* parameter) {
 }
 
 void uiTask(void* parameter) {
+    bool prevRemoved = g_logger.isRemoved();
+    bool prevReady = g_logger.isReady();
+    static uint32_t lastMountAttemptMs = 0;
     while (true) {
+        uint32_t nowMs = millis();
+        if ((g_logger.isRemoved() || !g_logger.isReady()) && nowMs - lastMountAttemptMs >= 2000) {
+            bool mounted = g_logger.begin(PIN_SD_CS, g_spi, &g_config);
+            lastMountAttemptMs = nowMs;
+            if (mounted) {
+                g_logger.resume();
+                g_sdNotifier.markPresent();
+            }
+        }
+
         utils::SensorMetrics metrics;
         bool hasMetrics = false;
         portENTER_CRITICAL(&g_metricsMux);
@@ -308,10 +362,32 @@ void uiTask(void* parameter) {
         }
         portEXIT_CRITICAL(&g_metricsMux);
 
+        bool removed = g_logger.isRemoved();
+        bool ready = g_logger.isReady();
+
+        if (removed && !prevRemoved) {
+            g_sdNotifier.markAbsent();
+            g_sdNotifier.defer();
+        } else if (!removed && ready && !prevReady) {
+            g_sdNotifier.markPresent();
+        } else if (!ready && prevReady && !removed) {
+            g_sdNotifier.markAbsent();
+        } else if (!ready && !removed && !g_sdNotifier.absent) {
+            g_sdNotifier.markAbsent();
+        }
+
+        if (ready && !removed && g_logger.isPaused()) {
+            g_logger.resume();
+        }
+
+        g_sdNotifier.update(g_ui);
+
         if (hasMetrics) {
             g_ui.setMetrics(metrics);
         }
         g_ui.update();
+        prevRemoved = removed;
+        prevReady = ready;
         vTaskDelay(pdMS_TO_TICKS(50));
     }
 }


### PR DESCRIPTION
## Summary
- add a remount backoff timer in the UI task so the system retries mounting the SD card every two seconds when it is missing or safely removed
- resume logging and clear the SD absence notifier as soon as a remount succeeds to stop the warning overlay

## Testing
- platformio run *(fails: PlatformIO CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dba7db8ccc8320b40b72970b02376c