### PR TITLE
Fully reset SD stack before SD card remounts

### DIFF
--- a/lib/LcdUI/LcdUI.cpp
+++ b/lib/LcdUI/LcdUI.cpp
@@ -37,11 +37,47 @@ void LcdUI::setCalibrationCallback(CalibrationCallback cb) {
     _calibrationCallback = cb;
 }
 
+void LcdUI::showTemporaryMessage(const char* msg, uint32_t durationMs) {
+    _overlayText = msg ? msg : "";
+    _overlayEndMs = millis() + durationMs;
+    _overlayActive = true;
+    _overlayCachedLine[0] = "";
+    _overlayCachedLine[1] = "";
+    if (_lcd) {
+        _lcd->clear();
+    }
+    _scroll.cachedLine[0] = "";
+    _scroll.cachedLine[1] = "";
+}
+
 void LcdUI::setMetrics(const utils::SensorMetrics& metrics) {
     _metrics = metrics;
     _hasMetrics = true;
     _lastMetricsTimestamp = metrics.timestamp;
     rebuildScrollBuffers();
+}
+
+String LcdUI::centerText(const String& text) const {
+    String line = text;
+    if (line.length() > 16) {
+        line = line.substring(0, 16);
+    }
+    size_t len = line.length();
+    if (len >= 16) {
+        return line;
+    }
+    size_t totalPad = 16 - len;
+    size_t leftPad = totalPad / 2;
+    size_t rightPad = totalPad - leftPad;
+    String padded;
+    for (size_t i = 0; i < leftPad; ++i) {
+        padded += ' ';
+    }
+    padded += line;
+    for (size_t i = 0; i < rightPad; ++i) {
+        padded += ' ';
+    }
+    return padded;
 }
 
 void LcdUI::ensureCustomGlyphs() {
@@ -106,6 +142,32 @@ void LcdUI::update() {
 
     ensureCustomGlyphs();
     _buttons->update();
+
+    uint32_t now = millis();
+    if (_overlayActive && now >= _overlayEndMs) {
+        _overlayActive = false;
+        _overlayText = "";
+        _overlayCachedLine[0] = "";
+        _overlayCachedLine[1] = "";
+        if (_lcd) {
+            _lcd->clear();
+        }
+        _scroll.cachedLine[0] = "";
+        _scroll.cachedLine[1] = "";
+    }
+
+    if (!_overlayActive && _buttons->bothHeldFor(3000)) {
+        if (_logger) {
+            _logger->pause();
+            _logger->safeRemove();
+        }
+        showTemporaryMessage("SD removed safely", 3000);
+    }
+
+    if (_overlayActive) {
+        renderOverlay();
+        return;
+    }
 
     float joyX = _joystick->readX();
     float joyY = _joystick->readY();
@@ -214,6 +276,46 @@ void LcdUI::renderScrollLine(uint8_t row, const String& label, const std::vector
         _lcd->setCursor(0, row);
         _lcd->print(fullLine);
         _scroll.cachedLine[row] = fullLine;
+    }
+}
+
+void LcdUI::renderOverlay() {
+    if (!_lcd) {
+        return;
+    }
+    String text = _overlayText;
+    String line1;
+    String line2;
+    if (text.length() <= 16) {
+        line1 = centerText(text);
+        line2 = centerText("");
+    } else {
+        int splitIndex = text.lastIndexOf(' ', 16);
+        if (splitIndex < 0) {
+            splitIndex = 16;
+        }
+        line1 = text.substring(0, splitIndex);
+        line1.trim();
+        line2 = text.substring(splitIndex);
+        line2.trim();
+        if (line1.length() > 16) {
+            line1 = line1.substring(0, 16);
+        }
+        if (line2.length() > 16) {
+            line2 = line2.substring(0, 16);
+        }
+        line1 = centerText(line1);
+        line2 = centerText(line2);
+    }
+    if (_overlayCachedLine[0] != line1) {
+        _lcd->setCursor(0, 0);
+        _lcd->print(line1);
+        _overlayCachedLine[0] = line1;
+    }
+    if (_overlayCachedLine[1] != line2) {
+        _lcd->setCursor(0, 1);
+        _lcd->print(line2);
+        _overlayCachedLine[1] = line2;
     }
 }
 

--- a/lib/LcdUI/LcdUI.h
+++ b/lib/LcdUI/LcdUI.h
@@ -20,6 +20,8 @@ class LcdUI {
     void update();
     void setMetrics(const utils::SensorMetrics& metrics);
     void setCalibrationCallback(CalibrationCallback cb);
+    void showTemporaryMessage(const char* msg, uint32_t durationMs);
+    bool isOverlayActive() const { return _overlayActive; }
 
   private:
     enum class ScreenState {
@@ -91,6 +93,8 @@ class LcdUI {
     const __FlashStringHelper* calibrationLabel(CalibrationEditor::Item item) const;
     float calibrationValue(CalibrationEditor::Item item) const;
     float calibrationStep(CalibrationEditor::Item item) const;
+    void renderOverlay();
+    String centerText(const String& text) const;
 
     LiquidCrystal_I2C* _lcd = nullptr;
     Buttons* _buttons = nullptr;
@@ -109,6 +113,10 @@ class LcdUI {
     CalibrationEditor _calEditor;
     time_t _lastMetricsTimestamp = 0;
     unsigned long _lastInputMillis = 0;
+    bool _overlayActive = false;
+    String _overlayText;
+    uint32_t _overlayEndMs = 0;
+    String _overlayCachedLine[2];
 
     uint8_t _glyphMu = 0;
     uint8_t _glyphEta = 1;

--- a/lib/SdLogger/SdLogger.h
+++ b/lib/SdLogger/SdLogger.h
@@ -10,11 +10,17 @@ class ConfigService;
 
 class SdLogger {
   public:
-    bool begin(uint8_t csPin, SPIClass& spi, ConfigService* config);
+    bool begin(uint8_t csPin, uint8_t sckPin, uint8_t misoPin, uint8_t mosiPin, SPIClass& spi,
+               ConfigService* config);
     void update();
     void log(const utils::SensorMetrics& metrics);
     void requestEventSnapshot();
     bool isReady() const { return _sdReady; }
+    bool isRemoved() const { return _removed; }
+    void pause() { _paused = true; }
+    void resume();
+    void safeRemove();
+    bool isPaused() const { return _paused; }
     bool hasEventActive() const { return _eventActive; }
 
   private:
@@ -34,12 +40,15 @@ class SdLogger {
     void closeEventFile();
     void flushFiles();
     void syncBufferLimit();
+    void powerOffCard();
 
     SdFat32 _sd;
     File32 _logFile;
     File32 _eventFile;
     String _currentLogPath;
     bool _sdReady = false;
+    bool _paused = false;
+    bool _removed = false;
     bool _eventRequested = false;
     bool _eventActive = false;
     time_t _eventEndTime = 0;


### PR DESCRIPTION
## Summary
- extend `SdLogger::begin` to reinitialize SPI with explicit pins and tear down any previous session before mounting
- tear down SdFat and SPI resources, releasing chip select when performing a safe remove
- debounce remount attempts in `uiTask` while supplying the SPI pin map for each retry and clearing absence notifications on success

## Testing
- platformio run *(fails: PlatformIO CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dba7db8ccc8320b40b72970b02376c